### PR TITLE
fix mapping on group b disposition of arrestee

### DIFF
--- a/tools/nibrs-xmlfile/src/main/java/org/search/nibrs/xmlfile/importer/XmlIncidentBuilder.java
+++ b/tools/nibrs-xmlfile/src/main/java/org/search/nibrs/xmlfile/importer/XmlIncidentBuilder.java
@@ -320,7 +320,7 @@ public class XmlIncidentBuilder extends AbstractIncidentBuilder{
 		arrestee.setRace(XmlUtils.xPathStringSearch(reportElement, "nc:Person/j:PersonRaceNDExCode"));
 		arrestee.setEthnicity(XmlUtils.xPathStringSearch(reportElement, "nc:Person/j:PersonEthnicityCode"));
 		arrestee.setResidentStatus(XmlUtils.xPathStringSearch(reportElement, "nc:Person/j:PersonResidentCode"));
-		arrestee.setDispositionOfArresteeUnder18(XmlUtils.xPathStringSearch(reportElement, "nc:Person/j:ArresteeJuvenileDispositionCode"));
+		arrestee.setDispositionOfArresteeUnder18(XmlUtils.xPathStringSearch(reportElement, "j:Arrestee/j:ArresteeJuvenileDispositionCode"));
 		
 		for (NIBRSError e : newErrorList) {
 			e.setReport(ret);

--- a/tools/nibrs-xmlfile/src/test/java/org/search/nibrs/xmlfile/importer/XmlIncidentBuilderGroupBReportTest.java
+++ b/tools/nibrs-xmlfile/src/test/java/org/search/nibrs/xmlfile/importer/XmlIncidentBuilderGroupBReportTest.java
@@ -79,7 +79,7 @@ public class XmlIncidentBuilderGroupBReportTest {
 		assertThat(arrestee.getEthnicity(), is("N"));
 		assertThat(arrestee.getResidentStatus(), is("R"));
 		assertThat(arrestee.getSex(), is("M"));
-		assertThat(arrestee.getDispositionOfArresteeUnder18(), is(nullValue()));
+		assertThat(arrestee.getDispositionOfArresteeUnder18(), is("H"));
 		assertThat(arrestee.getArresteeSequenceNumber().getValue(), is(1));
 		
 		assertThat(arrestee.getArrestDate().getValue(), is(LocalDate.of(2016, 2, 28)));


### PR DESCRIPTION
The mapping  for Disposition of Arrestee Under 18 is incorrect on Group B.

It should be:
nibrs:Report/j:Arrestee/j:ArresteeJuvenileDispositionCode






